### PR TITLE
Fix query bug in function recurseChapters()

### DIFF
--- a/comiccontrol/includes/classes.php
+++ b/comiccontrol/includes/classes.php
@@ -1262,7 +1262,7 @@ class CC_Comic extends CC_Module{
 					}
 				
 					//display the chapter name
-					$stmt->execute(['storyline' => $arr['id']]);
+					$stmt->execute(['storyline' => $arr['id'],'comic' => $this->id]);
 					$pages = $stmt->fetchAll();
 					echo '<div class="cc-storyline-text"><div class="cc-storyline-header"><a href="' . $ccsite->root . $this->slug . '/' . $firstpage['slug'] . '">' . 
 					$arr['name'] . '</a></div>';


### PR DESCRIPTION
SQL query for chapter name in function recurseChapters() does not specify variable 'comic' which causes comic archive to fail to finish rendering.

